### PR TITLE
add whitelist script to yarn run

### DIFF
--- a/addrHelper.ts
+++ b/addrHelper.ts
@@ -1,0 +1,10 @@
+import { Bech32 } from '@cosmjs/encoding';
+
+exports.to_stars_addr = (addr: string) => {
+  if (!addr.startsWith('stars')) {
+    const { data } = Bech32.decode(addr);
+    const starsAddr = Bech32.encode('stars', data);
+    addr = starsAddr;
+  }
+  return addr;
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "init": "cosmwasm-cli --init scripts/init.ts --code 'process.exit(0)'",
     "mint": "cosmwasm-cli --init scripts/mint.ts --code 'process.exit(0)'",
     "batch-mint": "cosmwasm-cli --init scripts/mint-batch.ts --code 'process.exit(0)'",
+    "update-whitelist": "cosmwasm-cli --init scripts/update-whitelist.ts --code 'process.exit(0)'",
     "load": "cosmwasm-cli --init scripts/load.ts",
     "pinata-upload": "ts-node scripts/pinata-upload.ts"
   }

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -2,6 +2,7 @@ import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { calculateFee, coins, GasPrice } from '@cosmjs/stargate';
 
+const addrHelper = require('./addrHelper');
 const config = require('./config');
 
 function isValidHttpUrl(uri: string) {
@@ -54,7 +55,14 @@ async function main() {
   }
 
   const whitelist =
-    config.whitelist.length > 0 ? config.whitelist : null;
+    config.whitelist.length > 0
+      ? (function (tmp_whitelist: Array<string> = config.whitelist) {
+          tmp_whitelist.forEach(function (addr, index) {
+            tmp_whitelist[index] = addrHelper.to_stars_addr(addr);
+          });
+          return tmp_whitelist;
+        })()
+      : null;
 
   const instantiateFee = calculateFee(950_000, gasPrice);
 
@@ -87,8 +95,6 @@ async function main() {
   } else {
     msg.sg721_instantiate_msg.config.royalties = undefined;
   }
-
-  // console.log(JSON.stringify(msg, null, 2));
 
   const result = await client.instantiate(
     config.account,

--- a/scripts/mint.ts
+++ b/scripts/mint.ts
@@ -3,6 +3,7 @@ import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { calculateFee, coins, GasPrice } from '@cosmjs/stargate';
 import { Bech32 } from '@cosmjs/encoding';
 
+const addrHelper = require('./addrHelper');
 const config = require('./config');
 
 async function mintSender() {
@@ -73,12 +74,8 @@ async function mintTo(recipient: string) {
 }
 
 async function mintFor(tokenId: string, recipient: string) {
-  if (!recipient.startsWith('stars')) {
-    const { data } = Bech32.decode(recipient);
-    const starsAddr = Bech32.encode('stars', data);
-    recipient = starsAddr;
-  }
-  console.log('Minting token ' + tokenId + ' for', recipient);
+  let stars_recipient = addrHelper.to_stars_addr(recipient);
+  console.log('Minting token ' + tokenId + ' for', stars_recipient);
 
   const gasPrice = GasPrice.fromString('0stars');
   const wallet = await DirectSecp256k1HdWallet.fromMnemonic(
@@ -96,7 +93,12 @@ async function mintFor(tokenId: string, recipient: string) {
   const result = await client.execute(
     config.account,
     config.minter,
-    { mint_for: { token_id: Number(tokenId), recipient } },
+    {
+      mint_for: {
+        token_id: Number(tokenId),
+        recipient: stars_recipient,
+      },
+    },
     executeFee,
     'mint for',
     coins('100000000', 'ustars'),

--- a/scripts/mint.ts
+++ b/scripts/mint.ts
@@ -1,18 +1,21 @@
-import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
-import { calculateFee, coins, GasPrice } from "@cosmjs/stargate";
-import { Bech32 } from "@cosmjs/encoding";
+import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
+import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import { calculateFee, coins, GasPrice } from '@cosmjs/stargate';
+import { Bech32 } from '@cosmjs/encoding';
 
-const config = require("./config");
+const config = require('./config');
 
 async function mintSender() {
-  const gasPrice = GasPrice.fromString("0stars");
-  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(config.mnemonic, {
-    prefix: "stars",
-  });
+  const gasPrice = GasPrice.fromString('0stars');
+  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(
+    config.mnemonic,
+    {
+      prefix: 'stars',
+    },
+  );
   const client = await SigningCosmWasmClient.connectWithSigner(
     config.rpcEndpoint,
-    wallet
+    wallet,
   );
   const executeFee = calculateFee(300_000, gasPrice);
   const result = await client.execute(
@@ -20,31 +23,36 @@ async function mintSender() {
     config.minter,
     { mint: {} },
     executeFee,
-    "mint to sender",
-    coins("100000000", "ustars")
+    'mint to sender',
+    coins('100000000', 'ustars'),
   );
-  const wasmEvent = result.logs[0].events.find((e) => e.type === "wasm");
+  const wasmEvent = result.logs[0].events.find(
+    (e) => e.type === 'wasm',
+  );
   console.info(
-    "The `wasm` event emitted by the contract execution:",
-    wasmEvent
+    'The `wasm` event emitted by the contract execution:',
+    wasmEvent,
   );
 }
 
 async function mintTo(recipient: string) {
-  if (!recipient.startsWith("stars")) {
+  if (!recipient.startsWith('stars')) {
     const { data } = Bech32.decode(recipient);
-    const starsAddr = Bech32.encode("stars", data);
+    const starsAddr = Bech32.encode('stars', data);
     recipient = starsAddr;
   }
-  console.log("Minting to: ", recipient);
+  console.log('Minting to: ', recipient);
 
-  const gasPrice = GasPrice.fromString("0stars");
-  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(config.mnemonic, {
-    prefix: "stars",
-  });
+  const gasPrice = GasPrice.fromString('0stars');
+  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(
+    config.mnemonic,
+    {
+      prefix: 'stars',
+    },
+  );
   const client = await SigningCosmWasmClient.connectWithSigner(
     config.rpcEndpoint,
-    wallet
+    wallet,
   );
   const executeFee = calculateFee(300_000, gasPrice);
   const result = await client.execute(
@@ -52,31 +60,36 @@ async function mintTo(recipient: string) {
     config.minter,
     { mint_to: { recipient: recipient } },
     executeFee,
-    "mint to",
-    coins("100000000", "ustars")
+    'mint to',
+    coins('100000000', 'ustars'),
   );
-  const wasmEvent = result.logs[0].events.find((e) => e.type === "wasm");
+  const wasmEvent = result.logs[0].events.find(
+    (e) => e.type === 'wasm',
+  );
   console.info(
-    "The `wasm` event emitted by the contract execution:",
-    wasmEvent
+    'The `wasm` event emitted by the contract execution:',
+    wasmEvent,
   );
 }
 
 async function mintFor(tokenId: string, recipient: string) {
-  if (!recipient.startsWith("stars")) {
+  if (!recipient.startsWith('stars')) {
     const { data } = Bech32.decode(recipient);
-    const starsAddr = Bech32.encode("stars", data);
+    const starsAddr = Bech32.encode('stars', data);
     recipient = starsAddr;
   }
-  console.log("Minting token " + tokenId + " for", recipient);
+  console.log('Minting token ' + tokenId + ' for', recipient);
 
-  const gasPrice = GasPrice.fromString("0stars");
-  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(config.mnemonic, {
-    prefix: "stars",
-  });
+  const gasPrice = GasPrice.fromString('0stars');
+  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(
+    config.mnemonic,
+    {
+      prefix: 'stars',
+    },
+  );
   const client = await SigningCosmWasmClient.connectWithSigner(
     config.rpcEndpoint,
-    wallet
+    wallet,
   );
   const executeFee = calculateFee(300_000, gasPrice);
 
@@ -85,13 +98,15 @@ async function mintFor(tokenId: string, recipient: string) {
     config.minter,
     { mint_for: { token_id: Number(tokenId), recipient } },
     executeFee,
-    "mint for",
-    coins("100000000", "ustars")
+    'mint for',
+    coins('100000000', 'ustars'),
   );
-  const wasmEvent = result.logs[0].events.find((e) => e.type === "wasm");
+  const wasmEvent = result.logs[0].events.find(
+    (e) => e.type === 'wasm',
+  );
   console.info(
-    "The `wasm` event emitted by the contract execution:",
-    wasmEvent
+    'The `wasm` event emitted by the contract execution:',
+    wasmEvent,
   );
 }
 
@@ -99,10 +114,10 @@ const args = process.argv.slice(6);
 console.log(args);
 if (args.length == 0) {
   await mintSender();
-} else if (args.length == 2 && args[0] == "--to") {
+} else if (args.length == 2 && args[0] == '--to') {
   await mintTo(args[1]);
-} else if (args.length == 3 && args[0] == "--for") {
+} else if (args.length == 3 && args[0] == '--for') {
   await mintFor(args[1], args[2]);
 } else {
-  console.log("Invalid arguments");
+  console.log('Invalid arguments');
 }

--- a/scripts/update-whitelist.ts
+++ b/scripts/update-whitelist.ts
@@ -35,7 +35,7 @@ async function updateWhitelist(add: string, remove: string) {
     config.rpcEndpoint,
     wallet,
   );
-  const executeFee = calculateFee(300_000, gasPrice);
+  const executeFee = calculateFee(600_000, gasPrice);
   const result = await client.execute(
     config.account,
     config.minter,

--- a/scripts/update-whitelist.ts
+++ b/scripts/update-whitelist.ts
@@ -5,15 +5,22 @@ import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
 import { calculateFee, coins, GasPrice } from '@cosmjs/stargate';
 
+const addrHelper = require('./addrHelper');
 const config = require('./config');
 
 async function updateWhitelist(add: string, remove: string) {
   const add_addresses = add == '' ? null : add.split(',');
   const remove_addresses = remove == '' ? null : remove.split(',');
   if (add_addresses != null) {
+    add_addresses.forEach(function (addr, index) {
+      add_addresses[index] = addrHelper.to_stars_addr(addr);
+    });
     console.log('add addresses: ', add_addresses.join(','));
   }
   if (remove_addresses != null) {
+    remove_addresses.forEach(function (addr, index) {
+      remove_addresses[index] = addrHelper.to_stars_addr(addr);
+    });
     console.log('remove addresses: ', remove_addresses.join(','));
   }
 

--- a/scripts/update-whitelist.ts
+++ b/scripts/update-whitelist.ts
@@ -56,17 +56,12 @@ async function updateWhitelist(add: string, remove: string) {
 }
 
 const args = process.argv.slice(6);
-console.log(args);
 if (args.length == 0) {
-  console.log(
-    'Invalid arguments. did you mean --add, --remove, or --update ?',
-  );
+  console.log('Invalid arguments. did you mean --add or --remove');
 } else if (args.length == 2 && args[0] == '--add') {
   await updateWhitelist(args[1], '');
 } else if (args.length == 2 && args[0] == '--remove') {
   await updateWhitelist('', args[1]);
-} else if (args.length == 3 && args[0] == '--update') {
-  await updateWhitelist(args[1], args[2]);
 } else {
   console.log('Invalid arguments');
 }

--- a/scripts/update-whitelist.ts
+++ b/scripts/update-whitelist.ts
@@ -1,0 +1,74 @@
+// add and remove must be comma delimited strings
+//-----------------------------------------------
+
+import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
+import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing';
+import { calculateFee, coins, GasPrice } from '@cosmjs/stargate';
+
+const config = require('./config');
+
+async function updateWhitelist(add: string, remove: string) {
+  const add_addresses = add == '' ? null : add.split(',');
+  const remove_addresses = remove == '' ? null : remove.split(',');
+  if (add_addresses != null) {
+    console.log('add addresses: ', add_addresses.join(','));
+  }
+  if (remove_addresses != null) {
+    console.log('remove addresses: ', remove_addresses.join(','));
+  }
+
+  const gasPrice = GasPrice.fromString('0stars');
+  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(
+    config.mnemonic,
+    {
+      prefix: 'stars',
+    },
+  );
+  const client = await SigningCosmWasmClient.connectWithSigner(
+    config.rpcEndpoint,
+    wallet,
+  );
+  const executeFee = calculateFee(300_000, gasPrice);
+  const result = await client.execute(
+    config.account,
+    config.minter,
+    {
+      update_whitelist: {
+        add_addresses: add_addresses,
+        remove_addresses: remove_addresses,
+      },
+    },
+    executeFee,
+    'update whitelist',
+  );
+  const wasmEvent = result.logs[0].events.find(
+    (e) => e.type === 'wasm',
+  );
+  console.info(
+    'The `wasm` event emitted by the contract execution:',
+    wasmEvent,
+  );
+
+  let res = await client.queryContractSmart(config.minter, {
+    whitelist_addresses: {},
+  });
+  console.log(res);
+}
+
+// yarn run add-whitelist ['stars10w5eulj60qp3cfqa0hkmke78qdy2feq6x9xdmd'] ['stars1c0d5qjavfkd7y4rcs9wa3s8w8l6e2dt58elscj']
+
+const args = process.argv.slice(6);
+console.log(args);
+if (args.length == 0) {
+  console.log(
+    'Invalid arguments. did you mean --add, --remove, or --update ?',
+  );
+} else if (args.length == 2 && args[0] == '--add') {
+  await updateWhitelist(args[1], '');
+} else if (args.length == 2 && args[0] == '--remove') {
+  await updateWhitelist('', args[1]);
+} else if (args.length == 3 && args[0] == '--update') {
+  await updateWhitelist(args[1], args[2]);
+} else {
+  console.log('Invalid arguments');
+}

--- a/scripts/update-whitelist.ts
+++ b/scripts/update-whitelist.ts
@@ -55,8 +55,6 @@ async function updateWhitelist(add: string, remove: string) {
   console.log(res);
 }
 
-// yarn run add-whitelist ['stars10w5eulj60qp3cfqa0hkmke78qdy2feq6x9xdmd'] ['stars1c0d5qjavfkd7y4rcs9wa3s8w8l6e2dt58elscj']
-
 const args = process.argv.slice(6);
 console.log(args);
 if (args.length == 0) {


### PR DESCRIPTION
Fix #6 

Allow creator to add / remove / update whitelist addresses. Returns full list of whitelist_addresses if executed successfully.

`yarn run update-whitelist --add 'addr1,addr2,addr3'`
`yarn run update-whitelist --remove 'addr1,addr2,addr3'`
`yarn run update-whitelist --update 'addr4,addr5,addr6' 'addr1,addr2,addr3'`